### PR TITLE
Empty the gcomm:// for pxc-node2 and pxc-node3

### DIFF
--- a/galera_sync_replication/pxc-node2.yaml
+++ b/galera_sync_replication/pxc-node2.yaml
@@ -28,7 +28,7 @@ spec:
         - name: GALERA_CLUSTER
           value: "true"
         - name: WSREP_CLUSTER_ADDRESS
-          value: gcomm://10.244.100.1
+          value: gcomm://
         - name: WSREP_SST_USER
           value: sst
         - name: WSREP_SST_PASSWORD

--- a/galera_sync_replication/pxc-node3.yaml
+++ b/galera_sync_replication/pxc-node3.yaml
@@ -28,7 +28,7 @@ spec:
         - name: GALERA_CLUSTER
           value: "true"
         - name: WSREP_CLUSTER_ADDRESS
-          value: gcomm://10.100.152.192
+          value: gcomm://
         - name: WSREP_SST_USER
           value: sst
         - name: WSREP_SST_PASSWORD


### PR DESCRIPTION
The pxc-node2.yaml and pxc-node3.yaml env WSREP_CLUSTER_ADDRESS is
set with hardcoded addresses such as `gcomm://10.244.100.1` and
`gcomm://10.100.152.192`. According to the docker images
entrypoint.sh

https://github.com/CaptTofu/percona_xtradb_cluster_docker/blob/master/docker-entrypoint.sh#L120

The `gcomm://` should be empty without any addresses. So that the
script help it to locate peer nodes by environment variables, such
as PXC_NODE1_SERVICE_HOST, PXC_NODE2_SERVICE_HOST,
PXC_NODE3_SERVICE_HOST. Otherwise the if statement will be skipped.

Besides, these hardcode addresses are confusing to new users.

This patch clears those WSREP_CLUSTER_ADDRESS and leaves only
`gcomm://`.
