### PR TITLE
Change container names as their manifest names

### DIFF
--- a/galera_sync_replication/pxc-node2.yaml
+++ b/galera_sync_replication/pxc-node2.yaml
@@ -10,7 +10,7 @@ spec:
         limits: 
           cpu: 0.5
       image: capttofu/percona_xtradb_cluster_5_6:latest
-      name: pxc-node1
+      name: pxc-node2
       ports:
         - containerPort: 3306
           hostPort: 3306

--- a/galera_sync_replication/pxc-node3.yaml
+++ b/galera_sync_replication/pxc-node3.yaml
@@ -10,7 +10,7 @@ spec:
         limits: 
           cpu: 0.5
       image: capttofu/percona_xtradb_cluster_5_6:latest
-      name: pxc-node1
+      name: pxc-node3
       ports:
         - containerPort: 3306
           hostPort: 3306


### PR DESCRIPTION
The pxc-node2.yaml and pxc-node3.yaml container name is still
'pxc-node1'. Change them to reflex the manifest file names
accordingly.
